### PR TITLE
Frequency & impact are like outputs & outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,16 @@ For more background on the thinking behind our current feedback process, [watch 
 
 ## How to interpret "frequency" & "impact"
 
-**Frequecy** & **impact** are similar to [outputs & outcomes](https://hbr.org/2012/11/its-not-just-semantics-managing-outcomes). **Frequency** is important, it describes the consistency of a pivot's efforts. **Impact** is related and perhaps more important, it speaks to whether these efforts were effective.
+All checkboxes are optional. Only check boxes for what's been observed and is applicable.
 
 ### FREQUENCY
 
-- Have you observed a pivot do this? 
+- Have you observed a pivot do this?
   - Don't check anything unless you have
   - When you observed this: 
     - Did it require prompting? Check "Only when asked"
     - Is consistent & unprompted? Check "Appropriately"
     - Have they sometimes needed prompting? Check "Occassionaly"
-    - Is it more nuanced? Use a combination of these boxes
 
 ### IMPACT
 
@@ -34,6 +33,8 @@ For more background on the thinking behind our current feedback process, [watch 
   - Did something get worse? Check "Low"
   - Is there room to make more of a difference than it did? Check both boxes
   - Please ensure managers have enough context; via the space in the form or shared directly with them
+
+**Frequecy** & **impact** are similar to [outputs & outcomes](https://hbr.org/2012/11/its-not-just-semantics-managing-outcomes). **Frequency** is important, it describes the consistency of a pivot's efforts. **Impact** is related and perhaps more important, it speaks to whether these efforts were effective.
 
 ## Want to contribute?
 **This repo is under active construction** and we welcome your help in improving

--- a/README.md
+++ b/README.md
@@ -5,28 +5,35 @@ This *public* repo contains the set of skills, organized by "area" and "P-level"
 Have questions about how to interpret all of this?  Ask your manager, or open an issue on this repo!
 
 ## Motivation
+
 We intend for the skills listed in this repo to describe the *impact* that a Pivot has.  We're trying to not focus too much on specific activities.
 
 This is because we want to avoid perverse incentives or "gamifiying" the performance of activities to the detriment of outcomes.  Also, there is often more than one activity, or way of doing an activity, that can lead to a particular outcome.  So we want to align our standards with positive outcomes for our teams, our customers, and our company.
 
 For more background on the thinking behind our current feedback process, [watch this video](https://sites.google.com/a/pivotal.io/cloud-foundry/resources/events-recordings/tech-talks/tt_feedback).
 
-## How to interpret "impact" and "frequency"
+## How to interpret "frequency" & "impact"
 
-- **IMPACT: High**: When Pivot does this line item, they do it well. Roughly this maps to meeting expectations and above.
+**Frequecy** & **impact** are similar to [outputs & outcomes](https://hbr.org/2012/11/its-not-just-semantics-managing-outcomes). **Frequency** is important, it describes the consistency of a pivot's efforts. **Impact** is related and perhaps more important, it speaks to whether these efforts were effective.
 
-- **IMPACT: Low**: When Pivot does this line item, they could do it better.  Roughly this maps to not meeting expectations and below.  When marking this, please provide additional context (there's space on the form, or share directly with the Pivot's manager).
+### FREQUENCY
 
-- **FREQUENCY**: This helps with the “when” from above. This is about *consistency* and *taking initiative*.
+- Have you observed a pivot do this? 
+  - Don't check anything unless you have
+  - When you observed this: 
+    - Did it required prompting? Check "Only when asked"
+    - Is consistent & unprompted? Check "Appropriately"
+    - Have they sometimes needed prompting? Check "Occassionaly"
+    - Is it more nuanced? Use a combination of these boxes
 
-All boxes are optional.  Use them any any combination:
+### IMPACT
 
-- Example 1: If the Pivot is having a “neutral” or "unknown" impact for a skill, then leave "impact" blank and use frequency axis only.
-
-- Example 2: If a line item isn't applicable for any reason, then leave the entire line item blank.
-
-- Example 3: If a Pivot often meets expectations, but still has some room to grow, then check *both* "IMPACT: high" *and* "IMPACT: low".
-
+- What difference have they made?
+  - Leave **impact** blank and use **frequency** only if it isn't clear or if they haven't yet made a difference
+  - Did it improve something? Check "High"
+  - Did something get worse? Check "Low"
+  - Is there room to make more of a difference than it did? Check both boxes.
+  - Please ensure managers have enough context; via the space in the form or shared directly with them
 
 ## Want to contribute?
 **This repo is under active construction** and we welcome your help in improving

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more background on the thinking behind our current feedback process, [watch 
 - Have you observed a pivot do this? 
   - Don't check anything unless you have
   - When you observed this: 
-    - Did it required prompting? Check "Only when asked"
+    - Did it require prompting? Check "Only when asked"
     - Is consistent & unprompted? Check "Appropriately"
     - Have they sometimes needed prompting? Check "Occassionaly"
     - Is it more nuanced? Use a combination of these boxes
@@ -32,7 +32,7 @@ For more background on the thinking behind our current feedback process, [watch 
   - Leave **impact** blank and use **frequency** only if it isn't clear or if they haven't yet made a difference
   - Did it improve something? Check "High"
   - Did something get worse? Check "Low"
-  - Is there room to make more of a difference than it did? Check both boxes.
+  - Is there room to make more of a difference than it did? Check both boxes
   - Please ensure managers have enough context; via the space in the form or shared directly with them
 
 ## Want to contribute?

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All checkboxes are optional. Only check boxes for what's been observed and is ap
   - Don't check anything unless you have
   - When you observed this: 
     - Did it require prompting? Check "Only when asked"
-    - Is consistent & unprompted? Check "Appropriately"
+    - Is it consistent & unprompted? Check "Appropriately"
     - Have they sometimes needed prompting? Check "Occassionaly"
 
 ### IMPACT
@@ -34,7 +34,7 @@ All checkboxes are optional. Only check boxes for what's been observed and is ap
   - Is there room to make more of a difference than it did? Check both boxes
   - Please ensure managers have enough context; via the space in the form or shared directly with them
 
-**Frequecy** & **impact** are similar to [outputs & outcomes](https://hbr.org/2012/11/its-not-just-semantics-managing-outcomes). **Frequency** is important, it describes the consistency of a pivot's efforts. **Impact** is related and perhaps more important, it speaks to whether these efforts were effective.
+**Frequency** & **impact** are similar to [outputs & outcomes](https://hbr.org/2012/11/its-not-just-semantics-managing-outcomes). **Frequency** is important, it describes the consistency of a pivot's efforts. **Impact** is related and perhaps more important, it speaks to whether these efforts were effective.
 
 ## Want to contribute?
 **This repo is under active construction** and we welcome your help in improving


### PR DESCRIPTION
I've often described frequency & impact as similar to outputs & outcomes respectively. I think this is well aligned with the existing descriptions, but adds additional guidance that I've seen reduce bias & subjectivity. I've used this description to guide folks sharing feedback toward concrete observations instead of subjective judgement.

This description of outcomes & outputs helped me: https://hbr.org/2012/11/its-not-just-semantics-managing-outcomes

"Outcomes are the difference made by the outputs: better traffic flow, shorter travel times, and fewer accidents."

"Outputs are important products, services, profits, and revenues: the What. Outcomes create meanings, relationships, and differences: the Why. Outputs, such as revenue and profit, enable us to fund outcomes; but without outcomes, there is no need for outputs."