### PR TITLE
Update wording for "provides basic input" technical skill

### DIFF
--- a/yaml/skills.yaml
+++ b/yaml/skills.yaml
@@ -4,7 +4,7 @@ skills:
   area: technical-execution
   level: p1
 - id: s11573987
-  description: Provides basic input into pair's progress
+  description: Provides basic input into pair's progress on a story while pairing
   area: technical-execution
   level: p1
 - id: s63dd6893


### PR DESCRIPTION
I did feedback interviews with some folks who interpreted this skill
as "provides basic mentoring to their pair, and input on their pair's
career progress". I've updated the description to make it clearer that
this is a basic, early P1 level of contributing at a minimal level to
story progress.

I wasn't sure if I should update both the yaml and the areas of contribution in the table. For now, I've only updated the yaml. If you want me to update the table as well, let me know and I'm happy to add that.