### PR TITLE
Update the "leaving space for others" arc

### DIFF
--- a/yaml/skills.yaml
+++ b/yaml/skills.yaml
@@ -307,10 +307,6 @@ skills:
   description: Communicates clearly and kindly with team mates
   area: collaboration
   level: p1
-- id: s727682c5
-  description: Actively leaves space for others to share their ideas
-  area: collaboration
-  level: p1
 - id: s4ab0d417
   description: 'Is conscious and respectful of team''s agreements (eg: core working hours)'
   area: collaboration
@@ -323,6 +319,10 @@ skills:
   description: Pairs easily/successfully with most Pivots and/or teams
   area: collaboration
   level: p1
+- id: s727682c5
+  description: Actively leaves space for others to share their ideas
+  area: collaboration
+  level: p2
 - id: sdc8485fd
   description: Actively works to build a more inclusive team
   area: collaboration
@@ -347,6 +347,10 @@ skills:
   level: p2
 - id: s9cff8008
   description: Sets an example for clear and kind communication in a disagreement
+  area: collaboration
+  level: p3
+- id: s309df010
+  description: Actively works to ensure quieter teammates have room to share and get recognition for their ideas
   area: collaboration
   level: p3
 - id: s40b9df88
@@ -380,6 +384,10 @@ skills:
   level: p4
 - id: s841ab9ce
   description: Knows their blind spots and actively works towards managing them
+  area: collaboration
+  level: p4
+- id: s23d923lk
+  description: Coaches pivots on how to facilitate conversations and meetings that allow other quieter teammates to share and get recognition for their ideas
   area: collaboration
   level: p4
 - id: s8e42e988

--- a/yaml/skills.yaml
+++ b/yaml/skills.yaml
@@ -320,7 +320,7 @@ skills:
   area: collaboration
   level: p1
 - id: s727682c5
-  description: Actively leaves space for others to share their ideas
+  description: 'Shares thoughts in a way that fosters further conversation and leaves space for others'
   area: collaboration
   level: p2
 - id: sdc8485fd


### PR DESCRIPTION
* Move "actively leaves space for others to share their ideas to P2"
because P1s are usually still developing enough ideas to be comfortable
sharing them at all. P2 is still the "do it yourself" level of
contribution, so I think this skill makes sense there.
* Add a P3 skill "Actively works to ensure quieter teammates have room
to share and get recognition for their ideas". P3 is doing things that
have a whole team impact. One can start in this arc by thinking about
the amount of space you take up in the room (P2), and then start
noticing and influencing the amount of space others take up in the room.
* Add a P4 skill "Coaches pivots on how to facilitate conversations and
meetings that allow other quieter teammates to share and get recognition
for their ideas". Noticing how much space one takes up in the room, and
how much space others take up, and balancing that, isn't an easy skill
to develop. Coaching other pivots on how to do this skill would have a
big impact on the team, by enabling other pivots.

Followup PR from https://github.com/pivotal-cf/areas-of-contribution/issues/32