### PR TITLE
clarify low-impact

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All checkboxes are optional. Only check boxes for what's been observed and is ap
 
 - Have you observed a pivot do this?
   - Don't check anything unless you have
-  - When you observed this: 
+  - When you observed this:
     - Did it require prompting? Check "Only when asked"
     - Is it consistent & unprompted? Check "Appropriately"
     - Have they sometimes needed prompting? Check "Occassionaly"
@@ -29,12 +29,12 @@ All checkboxes are optional. Only check boxes for what's been observed and is ap
 ### IMPACT
 
 - What difference have they made?
-  - Leave **impact** blank and use **frequency** only if it isn't clear or if they haven't yet made a difference
-  - Did it improve something? Check "High"
-  - Did something get worse? Check "Low"
-  - Is there room to make more of a difference than it did? Leave **impact** blank
-  - Have they started making a difference, but it isn't entirely visible or clear yet? Leave **impact** blank
-  - Please ensure managers have enough context; via the space in the form or shared directly with them
+  - Leave **impact** blank and use **frequency** only if it isn't clear or if they haven't yet made a difference.
+  - Did it improve something? Then check "High".
+  - Is this something where they are not contributing, and the lack of contribution is having a negative impact? Or did something get worse? Then check "Low".
+  - Is it somewhere in between?  Is there room to make more impact? Then leave **impact** blank, and check a frequency box.
+  - Have they started making a difference, but it isn't entirely visible or clear yet? Leave **impact** blank and check a frequency box.
+  - Please ensure managers have enough context; via the space in the form or shared directly with them.
 
 **Frequency** & **impact** are similar to [outputs & outcomes](https://hbr.org/2012/11/its-not-just-semantics-managing-outcomes). **Frequency** is important, it describes the consistency of a pivot's efforts. **Impact** is related and perhaps more important, it speaks to whether these efforts were effective.
 


### PR DESCRIPTION
the previous guidance suggested that "Low" impact was only for when someone made something actively worse.  Many managers have been recommending that "Low" also includes cases where the contribution isn't happening and that lack is problematic.