### PR TITLE
Update id for skill 

### DIFF
--- a/yaml/skills.yaml
+++ b/yaml/skills.yaml
@@ -229,7 +229,7 @@ skills:
   description: Has working knowledge about the product their team is building.
   area: domain-expertise
   level: p2
-- id: s2742e1ff
+- id: s0512815a
   description: Has working knowledge about how other teams/downstream consumers/customers use their product
   area: domain-expertise
   level: p2


### PR DESCRIPTION
In #45 we changed the semantics of the item, so we don't want to migrate old data.  

By changing the id, the old item will be removed.

whoops.

@utako @rnandi 