### PR TITLE
Add list of factors to main description for decision-making area

### DIFF
--- a/technical-decision-making.md
+++ b/technical-decision-making.md
@@ -11,7 +11,6 @@ Ability to weigh several factors when making technical decisions. Some factors t
   - adaptability of system / cost of change
   - support
 
-
 One example of success in this area: You have been noticing a lot of bugs arising the output of <command 1> and <command 2>. Additionally, you often see stories in the backlog around adding the same sort of features to both commands. You look through the code and notice that even though both commands are following separate code paths they are trying to accomplish roughly similar things. You share your findings with the team, and embark on a path to explore how to have both commands to follow similar code paths. After coming up with a plan, you get buy-in from your PM and other engineers to do this refactor as part of a larger epic. While you do this refactor you consider the maintainability and longer term extensibility of the system while you consolidate these paths. Finally, over time you observe that the number of bugs around those 2 commands decrease, and the team feels more comfortable navigating around that part of the codebase.
 
 ---

--- a/technical-decision-making.md
+++ b/technical-decision-making.md
@@ -1,7 +1,16 @@
 <!--- This file was GENERATED.  Do not edit it directly.  Instead, edit the corresponding YAML file --->
 ## Technical Decision-Making
 
-Ability to weigh several factors when making technical decisions. Some factors that could be considered are maintainability, security implications, performance implications, effects on other consumers, extensibility and adaptability of system, etc.
+Ability to weigh several factors when making technical decisions. Some factors that could be considered are:
+
+  - maintainability
+  - security implications
+  - performance implications
+  - effects on downstream consumers
+  - extensibility
+  - adaptability of system / cost of change
+  - support
+
 
 One example of success in this area: You have been noticing a lot of bugs arising the output of <command 1> and <command 2>. Additionally, you often see stories in the backlog around adding the same sort of features to both commands. You look through the code and notice that even though both commands are following separate code paths they are trying to accomplish roughly similar things. You share your findings with the team, and embark on a path to explore how to have both commands to follow similar code paths. After coming up with a plan, you get buy-in from your PM and other engineers to do this refactor as part of a larger epic. While you do this refactor you consider the maintainability and longer term extensibility of the system while you consolidate these paths. Finally, over time you observe that the number of bugs around those 2 commands decrease, and the team feels more comfortable navigating around that part of the codebase.
 
@@ -28,7 +37,7 @@ One example of success in this area: You have been noticing a lot of bugs arisin
 <tr>
 <td><strong>P2</strong></td>
 <td valign="top"><ul>
-  <li>Surfaces and discusses various factors (e.g. maintainability, extensibility, security) when approaching a technical decision, with support from other pivots to make the final decision.</li>
+  <li>Surfaces and discusses various factors (listed above in the skill area description) when approaching a technical decision, with support from other pivots to make the final decision.</li>
 
   <li>Makes sound technical decisions that conform to the team's existing architecture or vision.</li>
 </ul></td>

--- a/yaml/areas.yaml
+++ b/yaml/areas.yaml
@@ -123,8 +123,15 @@ areas:
   title: Technical Decision-Making
   description: >-
     Ability to weigh several factors when making technical decisions. Some factors that could be
-    considered are maintainability, security implications, performance implications, effects on
-    other consumers, extensibility and adaptability of system, etc.
+    considered are:
+
+      - maintainability
+      - security implications
+      - performance implications
+      - effects on downstream consumers
+      - extensibility
+      - adaptability of system / cost of change
+      - support
 
 
     One example of success in this area: You have been noticing a lot of bugs arising the output of

--- a/yaml/areas.yaml
+++ b/yaml/areas.yaml
@@ -133,7 +133,6 @@ areas:
       - adaptability of system / cost of change
       - support
 
-
     One example of success in this area: You have been noticing a lot of bugs arising the output of
     <command 1> and <command 2>. Additionally, you often see stories in the backlog around adding
     the same sort of features to both commands. You look through the code and notice that even

--- a/yaml/skills.yaml
+++ b/yaml/skills.yaml
@@ -728,7 +728,7 @@ skills:
   level: p1
 - id: sb3dee7be
   description: >-
-    Surfaces and discusses various factors (e.g. maintainability, extensibility, security) when approaching a technical
+    Surfaces and discusses various factors (listed above in the skill area description) when approaching a technical
     decision, with support from other pivots to make the final decision.
   area: technical-decision-making
   level: p2


### PR DESCRIPTION
There's an item on the first page that asks about basic consideration of these factors, and people need to go to the next page for a complete list of them. Seemed like an easy thing to streamline so people can fully answer the first page questions.