### PR TITLE
Suggestion: make skill explicitly about solo/small projects

### DIFF
--- a/yaml/skills.yaml
+++ b/yaml/skills.yaml
@@ -802,8 +802,8 @@ skills:
   level: p4
 - id: s83b7e358
   description: >-
-    Able to explore options and make technical decisions (without painting project in the corner)
-    when there are unknowns in the domain
+    As a solo or single pair: Able to explore options and make technical decisions (without painting project in the corner)
+    when there are unknowns in the domain.
   area: technical-decision-making
   level: p4
 - id: s9ed2f691


### PR DESCRIPTION
It seems like this advanced decision-making skill is often applicable on solo or very small projects. The wording and available examples have often lead to this assumption on the part of the interviewee. Solo exploration or prototypes are common advanced-level projects, so this feels useful. This change renders the skill more difficult to attain, but I think it's a good thing.

Thoughts?